### PR TITLE
Hide Available listings from the public investor inventory

### DIFF
--- a/netlify/functions/getDeals.js
+++ b/netlify/functions/getDeals.js
@@ -11,8 +11,10 @@ exports.handler = async () => {
       );
     }
 
-    // GROQ query to fetch deals
-    const query = `*[_type == "deal"]{
+    // GROQ query to fetch deals. Available (active) listings are excluded at
+    // the source so the public endpoint never exposes them — the inventory
+    // shows completed transactions only.
+    const query = `*[_type == "deal" && status != "Available"]{
       _id,
       timestamp,
       "price": price,

--- a/src/components/buyers/InventoryFilterBar.js
+++ b/src/components/buyers/InventoryFilterBar.js
@@ -15,7 +15,6 @@ const InventoryFilterBar = ({ onFilterChange }) => {
         onChange={(e) => onFilterChange(e.target.value)}
       >
         <option value="">All Statuses</option>
-        <option value="Available">Available</option>
         <option value="Assigned">Assigned</option>
         <option value="Sold">Sold</option>
       </select>


### PR DESCRIPTION
Per owner request: Available (active) properties no longer appear on /investordeals. Filtered in the getDeals GROQ query itself, so the public endpoint stops exposing active listings' addresses and media links entirely; the "Available" filter option is removed. Inventory now shows completed transactions (Assigned/Sold) only.

Verified: 13/13 tests pass, production build compiles, local gate green. Adversarial review skipped — two-line mechanical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)