### PR TITLE
Restore Available status in inventory (data fix belongs in Sanity)

### DIFF
--- a/netlify/functions/getDeals.js
+++ b/netlify/functions/getDeals.js
@@ -11,10 +11,8 @@ exports.handler = async () => {
       );
     }
 
-    // GROQ query to fetch deals. Available (active) listings are excluded at
-    // the source so the public endpoint never exposes them — the inventory
-    // shows completed transactions only.
-    const query = `*[_type == "deal" && status != "Available"]{
+    // GROQ query to fetch deals
+    const query = `*[_type == "deal"]{
       _id,
       timestamp,
       "price": price,

--- a/src/components/buyers/InventoryFilterBar.js
+++ b/src/components/buyers/InventoryFilterBar.js
@@ -15,6 +15,7 @@ const InventoryFilterBar = ({ onFilterChange }) => {
         onChange={(e) => onFilterChange(e.target.value)}
       >
         <option value="">All Statuses</option>
+        <option value="Available">Available</option>
         <option value="Assigned">Assigned</option>
         <option value="Sold">Sold</option>
       </select>


### PR DESCRIPTION
Reverts #5 per owner clarification: the "Available" filter option should remain — the issue is one stale Sanity record (the St. Louis deal marked Available when nothing is currently available). That gets corrected in Sanity Studio, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)