### PR TITLE
Lead pipeline: Supabase primary store, no Apps Script dependency

### DIFF
--- a/netlify/functions/newBuyer.js
+++ b/netlify/functions/newBuyer.js
@@ -1,9 +1,29 @@
 const axios = require("axios");
 require("dotenv").config();
 
+// PRIMARY store: Supabase. Publishable key is committed on purpose — it is
+// public by design and row-level security only permits INSERT with it.
+const SUPABASE_URL =
+  process.env.SUPABASE_URL || "https://ltpiqfgtfdzlgtqdghle.supabase.co";
+const SUPABASE_PUBLISHABLE_KEY =
+  process.env.SUPABASE_PUBLISHABLE_KEY ||
+  "sb_publishable_MIw-hDdAugdp8ZWpw__t-w_-d8wxhK8";
+
+// Best-effort mirrors. The sheet counts toward success; Netlify Forms is
+// opportunistic only (the SPA catch-all can fake a 200 for it).
 const GOOGLE_SCRIPT_URL = process.env.REACT_APP_GOOGLE_APPS_SCRIPT_URL_BUYER;
+const NETLIFY_FORMS_ORIGIN = process.env.URL || "https://hendrixventures.com";
+
+const SINK_TIMEOUT_MS = 3500;
 
 exports.handler = async (event) => {
+  if (event.httpMethod !== "POST") {
+    return {
+      statusCode: 405,
+      body: "Method Not Allowed",
+    };
+  }
+
   try {
     const buyerData = JSON.parse(event.body);
     if (!buyerData || typeof buyerData !== "object") {
@@ -12,20 +32,112 @@ exports.handler = async (event) => {
         body: JSON.stringify({ message: "Invalid buyer data" }),
       };
     }
-    const response = await axios.post(GOOGLE_SCRIPT_URL, buyerData, {
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
 
-    return {
-      statusCode: 200,
-      body: JSON.stringify({ message: "Success", data: response.data }),
-    };
-  } catch (error) {
+    // BuyerForm sends the phone as `number` (legacy CRM naming); accept
+    // `contact` too so nothing breaks if the client is ever cleaned up.
+    const contact = buyerData.number || buyerData.contact;
+    const requiredString = (v) => typeof v === "string" && v.trim() !== "";
+    const missing = [];
+    if (!requiredString(buyerData.firstName)) missing.push("firstName");
+    if (!requiredString(buyerData.lastName)) missing.push("lastName");
+    if (!requiredString(contact)) missing.push("number");
+    if (!requiredString(buyerData.email)) missing.push("email");
+    if (missing.length > 0) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ message: "Invalid buyer data", missing }),
+      };
+    }
+
+    const postSupabase = () =>
+      axios.post(
+        `${SUPABASE_URL}/rest/v1/investor_signups`,
+        {
+          first_name: buyerData.firstName,
+          last_name: buyerData.lastName,
+          contact,
+          email: buyerData.email,
+          market: buyerData.market || null,
+          buyer_type: buyerData.buyerType || null,
+          user_agent: event.headers["user-agent"] || null,
+          ip: event.headers["x-nf-client-connection-ip"] || null,
+          raw: buyerData,
+        },
+        {
+          headers: {
+            apikey: SUPABASE_PUBLISHABLE_KEY,
+            "Content-Type": "application/json",
+            Prefer: "return=minimal",
+          },
+          timeout: SINK_TIMEOUT_MS,
+        }
+      );
+
+    const postSheet = () =>
+      axios.post(GOOGLE_SCRIPT_URL, buyerData, {
+        headers: { "Content-Type": "application/json" },
+        timeout: SINK_TIMEOUT_MS,
+      });
+
+    const postNetlifyForm = () =>
+      axios.post(
+        `${NETLIFY_FORMS_ORIGIN}/`,
+        new URLSearchParams({
+          "form-name": "investor-signup",
+          firstName: buyerData.firstName,
+          lastName: buyerData.lastName,
+          contact,
+          email: buyerData.email,
+          market: buyerData.market || "",
+          buyerType: buyerData.buyerType || "",
+        }).toString(),
+        {
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          timeout: SINK_TIMEOUT_MS,
+        }
+      );
+
+    const [storeResult, sheetResult] = await Promise.allSettled([
+      postSupabase(),
+      GOOGLE_SCRIPT_URL ? postSheet() : Promise.resolve("skipped"),
+      postNetlifyForm(),
+    ]);
+
+    const stored = storeResult.status === "fulfilled";
+    if (!stored) {
+      const r = storeResult.reason;
+      console.error(
+        "Supabase insert failed:",
+        r && r.response
+          ? `${r.response.status} ${JSON.stringify(r.response.data)}`
+          : r && r.message
+      );
+    }
+    const sheetMirrored =
+      Boolean(GOOGLE_SCRIPT_URL) && sheetResult.status === "fulfilled";
+    if (GOOGLE_SCRIPT_URL && !sheetMirrored) {
+      console.warn(
+        "Buyer sheet mirror failed:",
+        sheetResult.reason && sheetResult.reason.message
+      );
+    }
+
+    if (stored || sheetMirrored) {
+      return {
+        statusCode: 200,
+        body: JSON.stringify({ message: "Success" }),
+      };
+    }
+    console.error("All verifiable buyer destinations failed");
     return {
       statusCode: 500,
-      body: JSON.stringify({ message: "Error", error: error.message }),
+      body: JSON.stringify({ message: "Error" }),
+    };
+  } catch (error) {
+    console.error("Error handling buyer signup:", error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ message: "Error" }),
     };
   }
 };

--- a/netlify/functions/sendLead.js
+++ b/netlify/functions/sendLead.js
@@ -1,11 +1,32 @@
 const axios = require("axios");
 require("dotenv").config();
 
+// PRIMARY lead store: Supabase. The publishable key below is intentionally
+// committed — it is public by design (like any client-side API key) and the
+// table's row-level security only allows INSERT with it: leads can never be
+// read, changed, or deleted using this key (verified: SELECT returns 401).
+const SUPABASE_URL =
+  process.env.SUPABASE_URL || "https://ltpiqfgtfdzlgtqdghle.supabase.co";
+const SUPABASE_PUBLISHABLE_KEY =
+  process.env.SUPABASE_PUBLISHABLE_KEY ||
+  "sb_publishable_MIw-hDdAugdp8ZWpw__t-w_-d8wxhK8";
+
+// MIRROR 1 (best-effort): legacy Google Apps Script -> Sheet. Counts toward
+// success because a 2xx from script.google.com means the sheet accepted it.
 const GOOGLE_SCRIPT_URL = process.env.REACT_APP_GOOGLE_APPS_SCRIPT_URL_LEAD;
+
+// MIRROR 2 (opportunistic ONLY): Netlify Forms. Deliberately excluded from
+// the success decision — the SPA catch-all redirect can answer this POST
+// with a 200 even when Netlify Forms did not record the submission.
+const NETLIFY_FORMS_ORIGIN = process.env.URL || "https://hendrixventures.com";
 
 // Forms completed faster than this are treated as bots. Kept low so that a
 // returning visitor who browser-autofills the whole form isn't dropped.
 const MIN_FILL_TIME_MS = 2000;
+// Sinks run in parallel, so worst-case wall time stays inside Netlify's 10s
+// function limit no matter how many sinks hang.
+const SINK_TIMEOUT_MS = 3500;
+const PG_INT4_MAX = 2147483647;
 
 exports.handler = async (event, context) => {
   // Allow only POST requests
@@ -18,6 +39,19 @@ exports.handler = async (event, context) => {
 
   try {
     const payload = JSON.parse(event.body);
+
+    // Server-side validation: never trust that the client form ran
+    const requiredString = (v) => typeof v === "string" && v.trim() !== "";
+    if (
+      !requiredString(payload.name) ||
+      !requiredString(payload.phone) ||
+      !requiredString(payload.address)
+    ) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ message: "Missing required fields" }),
+      };
+    }
 
     // Spam checks: honeypot filled, or submitted faster than a human could.
     // Respond with a fake success so bots get no signal to adapt to.
@@ -37,24 +71,91 @@ exports.handler = async (event, context) => {
       };
     }
 
-    // Spam-check fields never belong in the sheet; stamp the lead with the
-    // server's receipt time (client clocks are unreliable)
-    delete payload.fax;
-    delete payload.fillTimeMs;
-    payload.timestamp = new Date().toLocaleString("en-US", {
+    const lead = {
+      name: payload.name,
+      phone: payload.phone,
+      address: payload.address,
+    };
+    const receivedAt = new Date().toLocaleString("en-US", {
       timeZone: "America/New_York",
     });
 
-    const response = await axios.post(GOOGLE_SCRIPT_URL, payload, {
-      headers: { "Content-Type": "application/json" },
-    });
+    const postSupabase = () =>
+      axios.post(
+        `${SUPABASE_URL}/rest/v1/seller_leads`,
+        {
+          ...lead,
+          fill_time_ms: Math.min(Math.round(fillTimeMs), PG_INT4_MAX),
+          user_agent: event.headers["user-agent"] || null,
+          ip: event.headers["x-nf-client-connection-ip"] || null,
+          raw: payload,
+        },
+        {
+          headers: {
+            apikey: SUPABASE_PUBLISHABLE_KEY,
+            "Content-Type": "application/json",
+            Prefer: "return=minimal",
+          },
+          timeout: SINK_TIMEOUT_MS,
+        }
+      );
 
+    const postSheet = () =>
+      axios.post(
+        GOOGLE_SCRIPT_URL,
+        { ...lead, timestamp: receivedAt },
+        {
+          headers: { "Content-Type": "application/json" },
+          timeout: SINK_TIMEOUT_MS,
+        }
+      );
+
+    const postNetlifyForm = () =>
+      axios.post(
+        `${NETLIFY_FORMS_ORIGIN}/`,
+        new URLSearchParams({ "form-name": "seller-lead", ...lead }).toString(),
+        {
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          timeout: SINK_TIMEOUT_MS,
+        }
+      );
+
+    const [storeResult, sheetResult] = await Promise.allSettled([
+      postSupabase(),
+      GOOGLE_SCRIPT_URL ? postSheet() : Promise.resolve("skipped"),
+      postNetlifyForm(),
+    ]);
+
+    const stored = storeResult.status === "fulfilled";
+    if (!stored) {
+      const r = storeResult.reason;
+      console.error(
+        "Supabase insert failed:",
+        r && r.response
+          ? `${r.response.status} ${JSON.stringify(r.response.data)}`
+          : r && r.message
+      );
+    }
+    const sheetMirrored =
+      Boolean(GOOGLE_SCRIPT_URL) && sheetResult.status === "fulfilled";
+    if (GOOGLE_SCRIPT_URL && !sheetMirrored) {
+      console.warn(
+        "Sheet mirror failed:",
+        sheetResult.reason && sheetResult.reason.message
+      );
+    }
+
+    // The lead is safe only if a VERIFIABLE destination accepted it
+    if (stored || sheetMirrored) {
+      return {
+        statusCode: 200,
+        body: JSON.stringify({ message: "Lead sent successfully" }),
+      };
+    }
+    console.error("All verifiable lead destinations failed");
     return {
-      statusCode: 200,
-      body: JSON.stringify({
-        message: "Lead sent successfully",
-        googleResponse: response.data,
-      }),
+      statusCode: 500,
+      body: JSON.stringify({ message: "Failed to send lead" }),
     };
   } catch (error) {
     console.error("Error sending lead:", error);

--- a/public/index.html
+++ b/public/index.html
@@ -66,5 +66,21 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <!-- Hidden registrations for Netlify Forms. Submissions are relayed
+         server-side by the lead functions after spam checks; these exist so
+         Netlify's build detects the forms and shows entries in the dashboard. -->
+    <form name="seller-lead" data-netlify="true" hidden>
+      <input type="text" name="name" />
+      <input type="text" name="phone" />
+      <input type="text" name="address" />
+    </form>
+    <form name="investor-signup" data-netlify="true" hidden>
+      <input type="text" name="firstName" />
+      <input type="text" name="lastName" />
+      <input type="text" name="contact" />
+      <input type="email" name="email" />
+      <input type="text" name="market" />
+      <input type="text" name="buyerType" />
+    </form>
   </body>
 </html>

--- a/src/tests/newBuyer.test.js
+++ b/src/tests/newBuyer.test.js
@@ -1,0 +1,75 @@
+jest.mock("axios", () => ({ post: jest.fn() }));
+const axios = require("axios");
+const { handler } = require("../../netlify/functions/newBuyer");
+
+const SUPABASE_PATH = "/rest/v1/investor_signups";
+
+const post = (payload) =>
+  handler(
+    { httpMethod: "POST", headers: {}, body: JSON.stringify(payload) },
+    {}
+  );
+
+// EXACTLY the payload BuyerForm.handleSubmit constructs (BuyerForm.js:51-59):
+// the phone arrives as `number`, there is no `contact` and no `market` field.
+const realBuyerFormPayload = (overrides = {}) => ({
+  firstName: "Test",
+  lastName: "Investor",
+  email: "test@example.com",
+  investorLiftScore: 0,
+  number: "(404) 555-0142",
+  buyerType: "Cash Buyer",
+  level: "Potential Buyer",
+  ...overrides,
+});
+
+const callsTo = (fragment) =>
+  axios.post.mock.calls.filter(([url]) => url.includes(fragment));
+
+beforeEach(() => {
+  axios.post.mockReset();
+  axios.post.mockResolvedValue({ data: { ok: true } });
+});
+
+test("rejects non-POST requests", async () => {
+  const res = await handler({ httpMethod: "GET", headers: {} }, {});
+  expect(res.statusCode).toBe(405);
+});
+
+// Regression test: an earlier draft validated a `contact` field that the real
+// BuyerForm never sends (it sends `number`), rejecting every live signup.
+test("accepts the exact payload the live BuyerForm sends", async () => {
+  const res = await post(realBuyerFormPayload());
+  expect(res.statusCode).toBe(200);
+  const supabaseCalls = callsTo(SUPABASE_PATH);
+  expect(supabaseCalls).toHaveLength(1);
+  expect(supabaseCalls[0][1]).toMatchObject({
+    first_name: "Test",
+    last_name: "Investor",
+    contact: "(404) 555-0142",
+    email: "test@example.com",
+    buyer_type: "Cash Buyer",
+  });
+});
+
+test("rejects a signup with missing required fields before any sink", async () => {
+  const res = await post(realBuyerFormPayload({ email: "" }));
+  expect(res.statusCode).toBe(400);
+  expect(axios.post).not.toHaveBeenCalled();
+});
+
+test("a Netlify Forms 200 does NOT count as success when Supabase fails", async () => {
+  axios.post.mockImplementation((url) =>
+    url.includes(SUPABASE_PATH)
+      ? Promise.reject(new Error("supabase down"))
+      : Promise.resolve({ data: { ok: true } })
+  );
+  const res = await post(realBuyerFormPayload());
+  expect(res.statusCode).toBe(500);
+});
+
+test("returns 500 when every destination fails", async () => {
+  axios.post.mockRejectedValue(new Error("everything down"));
+  const res = await post(realBuyerFormPayload());
+  expect(res.statusCode).toBe(500);
+});

--- a/src/tests/sendLead.test.js
+++ b/src/tests/sendLead.test.js
@@ -2,8 +2,13 @@ jest.mock("axios", () => ({ post: jest.fn() }));
 const axios = require("axios");
 const { handler } = require("../../netlify/functions/sendLead");
 
+const SUPABASE_PATH = "/rest/v1/seller_leads";
+
 const post = (payload) =>
-  handler({ httpMethod: "POST", body: JSON.stringify(payload) }, {});
+  handler(
+    { httpMethod: "POST", headers: {}, body: JSON.stringify(payload) },
+    {}
+  );
 
 const legitLead = (overrides = {}) => ({
   name: "Test Seller",
@@ -14,30 +19,74 @@ const legitLead = (overrides = {}) => ({
   ...overrides,
 });
 
+const callsTo = (fragment) =>
+  axios.post.mock.calls.filter(([url]) => url.includes(fragment));
+
 beforeEach(() => {
   axios.post.mockReset();
   axios.post.mockResolvedValue({ data: { ok: true } });
 });
 
 test("rejects non-POST requests", async () => {
-  const res = await handler({ httpMethod: "GET" }, {});
+  const res = await handler({ httpMethod: "GET", headers: {} }, {});
   expect(res.statusCode).toBe(405);
 });
 
-test("forwards a legitimate lead with a server receipt timestamp and no spam-check fields", async () => {
+test("rejects a payload missing required fields before touching any sink", async () => {
+  const res = await post(legitLead({ name: "" }));
+  expect(res.statusCode).toBe(400);
+  expect(axios.post).not.toHaveBeenCalled();
+});
+
+test("stores a legitimate lead in Supabase with spam-check metadata", async () => {
   const res = await post(legitLead());
   expect(res.statusCode).toBe(200);
-  expect(axios.post).toHaveBeenCalledTimes(1);
-  const forwarded = axios.post.mock.calls[0][1];
-  expect(forwarded).not.toHaveProperty("fax");
-  expect(forwarded).not.toHaveProperty("fillTimeMs");
-  // Timestamp must be a readable date string stamped by the server
-  expect(forwarded.timestamp).toMatch(/\d{1,2}\/\d{1,2}\/\d{4}/);
+  const supabaseCalls = callsTo(SUPABASE_PATH);
+  expect(supabaseCalls).toHaveLength(1);
+  const [, body, config] = supabaseCalls[0];
+  expect(body).toMatchObject({
+    name: "Test Seller",
+    phone: "(404) 555-0142",
+    address: "123 Main St",
+    fill_time_ms: 10_000,
+  });
+  expect(config.headers.apikey).toBeTruthy();
+});
+
+test("clamps absurd fill times to the int4 column limit", async () => {
+  await post(legitLead({ fillTimeMs: 99_999_999_999 }));
+  const [, body] = callsTo(SUPABASE_PATH)[0];
+  expect(body.fill_time_ms).toBe(2147483647);
+});
+
+test("attempts the Netlify Forms mirror", async () => {
+  await post(legitLead());
+  const formCalls = axios.post.mock.calls.filter(([, body]) =>
+    String(body).includes("form-name=seller-lead")
+  );
+  expect(formCalls).toHaveLength(1);
+});
+
+test("a Netlify Forms 200 does NOT count as success when Supabase fails", async () => {
+  // The SPA catch-all can answer that POST with a 200 even when Netlify
+  // Forms recorded nothing, so it must never mask a lost lead.
+  axios.post.mockImplementation((url) =>
+    url.includes(SUPABASE_PATH)
+      ? Promise.reject(new Error("supabase down"))
+      : Promise.resolve({ data: { ok: true } })
+  );
+  const res = await post(legitLead());
+  expect(res.statusCode).toBe(500);
+});
+
+test("returns 500 when every destination fails", async () => {
+  axios.post.mockRejectedValue(new Error("everything down"));
+  const res = await post(legitLead());
+  expect(res.statusCode).toBe(500);
 });
 
 test("silently drops a lead when the honeypot is filled", async () => {
   const res = await post(legitLead({ fax: "https://spam.example" }));
-  // Fake success so bots get no signal
   expect(res.statusCode).toBe(200);
   expect(axios.post).not.toHaveBeenCalled();
 });
@@ -57,11 +106,35 @@ test("silently drops a lead with a missing or garbage fill time", async () => {
 test("accepts a slow autofill user (2s boundary)", async () => {
   const res = await post(legitLead({ fillTimeMs: 2000 }));
   expect(res.statusCode).toBe(200);
-  expect(axios.post).toHaveBeenCalledTimes(1);
+  expect(callsTo(SUPABASE_PATH)).toHaveLength(1);
 });
 
-test("returns 500 when the upstream webhook fails", async () => {
-  axios.post.mockRejectedValue(new Error("upstream down"));
-  const res = await post(legitLead());
-  expect(res.statusCode).toBe(500);
+test("a working sheet mirror saves the lead when Supabase is down", async () => {
+  jest.resetModules();
+  process.env.REACT_APP_GOOGLE_APPS_SCRIPT_URL_LEAD =
+    "https://script.google.com/macros/s/TEST/exec";
+  try {
+    // resetModules gives the re-required module a FRESH axios mock; all
+    // interaction must go through that instance
+    const freshAxios = require("axios");
+    freshAxios.post.mockReset();
+    freshAxios.post.mockImplementation((url) =>
+      url.includes(SUPABASE_PATH)
+        ? Promise.reject(new Error("supabase down"))
+        : Promise.resolve({ data: { ok: true } })
+    );
+    const fresh = require("../../netlify/functions/sendLead");
+    const res = await fresh.handler(
+      { httpMethod: "POST", headers: {}, body: JSON.stringify(legitLead()) },
+      {}
+    );
+    expect(res.statusCode).toBe(200);
+    const sheetCalls = freshAxios.post.mock.calls.filter(([url]) =>
+      url.includes("script.google.com")
+    );
+    expect(sheetCalls).toHaveLength(1);
+  } finally {
+    delete process.env.REACT_APP_GOOGLE_APPS_SCRIPT_URL_LEAD;
+    jest.resetModules();
+  }
 });


### PR DESCRIPTION
Per owner request: lead capture no longer depends on the broken Google Apps Script webhook or on any manual fix.

**Architecture**: seller + buyer submissions → Netlify function → parallel fan-out to (1) **Supabase `seller_leads`/`investor_signups`** — primary, durable, insert-only-key secured; (2) legacy Apps Script sheet — best-effort mirror, auto-resumes if the 403 is ever fixed; (3) Netlify Forms — opportunistic dashboard mirror, deliberately excluded from the success decision. The client shows success only when a verifiable destination accepted the lead.

**Security**: committed key is a Supabase *publishable* key (public by design); RLS allows INSERT only — reads/updates/deletes verified denied (401). Excess grants revoked. Residual risk: direct inserts bypassing the function's spam gates are possible with the public key (bounded: write-only, no PII exposure); Turnstile lands in the Phase 2 rebuild.

**Verification**: 23/23 tests pass incl. regression tests pinned to the exact live BuyerForm payload and to the "Netlify Forms 200 must not mask a lost lead" rule; production build compiles; adversarial review ran — its blocking findings (buyer payload field mismatch, untrustworthy form-mirror success signal) and all four important findings (timeout budget, missing validation, int4 overflow, test env leak) are fixed.

**Post-merge**: end-to-end production test will be run and verified directly in the Supabase table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)