### PR TITLE
Exclude the never-closed St. Louis record from the investor API

### DIFF
--- a/netlify/functions/getDeals.js
+++ b/netlify/functions/getDeals.js
@@ -30,10 +30,15 @@ exports.handler = async () => {
       params: { query },
     });
 
-    // Return the response as JSON
+    // Georgia deals only (the St. Louis record never closed — owner
+    // directive 2026-08-12; excluded here until deleted in Sanity)
+    const deals = (response.data.result || []).filter(
+      (d) => d.address && /\bGA\b/.test(d.address)
+    );
+
     return {
       statusCode: 200,
-      body: JSON.stringify(response.data.result),
+      body: JSON.stringify(deals),
     };
   } catch (error) {
     console.error("Error fetching deals from Sanity:", error);


### PR DESCRIPTION
Owner directive: the St. Louis deal never closed — remove it everywhere. This filters the public getDeals API to Georgia records on production; the redesign branch carries the same filter, and the owner will delete the source document in Sanity Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)