### PR TITLE
Mirror complete leads to dotato's inbound webhook

### DIFF
--- a/netlify/functions/submit-lead.js
+++ b/netlify/functions/submit-lead.js
@@ -14,6 +14,13 @@ const SUPABASE_PUBLISHABLE_KEY =
 const GOOGLE_SCRIPT_URL = process.env.REACT_APP_GOOGLE_APPS_SCRIPT_URL_LEAD;
 const NETLIFY_FORMS_ORIGIN = process.env.URL || "https://hendrixventures.com";
 
+// MIRROR 3 (opportunistic ONLY): dotato's inbound-lead webhook. Full URL
+// including its path token; unset = feature off. Complete submissions only —
+// dotato declines partials by design. Never counts toward the success
+// decision: the website's own store is the source of truth, and dotato
+// ingestion is idempotent on submissionId, so retries are safe.
+const DOTATO_LEADS_WEBHOOK_URL = process.env.DOTATO_LEADS_WEBHOOK_URL;
+
 const MIN_FILL_TIME_MS = 2000;
 const SINK_TIMEOUT_MS = 3500;
 const PG_INT4_MAX = 2147483647;
@@ -136,6 +143,29 @@ export const handler = async (event) => {
         }
       );
 
+    const postDotato = () =>
+      axios.post(
+        DOTATO_LEADS_WEBHOOK_URL,
+        {
+          stage: "complete",
+          submissionId: payload.submissionId || null,
+          address: payload.address,
+          name: payload.name,
+          phone: payload.phone,
+          email: requiredString(payload.email) ? payload.email : null,
+          timeline: requiredString(payload.timeline) ? payload.timeline : null,
+          consentTransactional: payload.consentTransactional === true,
+          consentMarketing: payload.consentMarketing === true,
+          consentVersion: CONSENT_VERSION,
+          pageUrl: payload.pageUrl || null,
+          receivedAt: new Date().toISOString(),
+        },
+        {
+          headers: { "Content-Type": "application/json" },
+          timeout: SINK_TIMEOUT_MS,
+        }
+      );
+
     const [storeResult, sheetResult] = await Promise.allSettled([
       insert({
         ...common,
@@ -151,6 +181,7 @@ export const handler = async (event) => {
       }),
       GOOGLE_SCRIPT_URL ? postSheet() : Promise.resolve("skipped"),
       postNetlifyForm(),
+      DOTATO_LEADS_WEBHOOK_URL ? postDotato() : Promise.resolve("skipped"),
     ]);
 
     const stored = storeResult.status === "fulfilled";

--- a/tests/functions/submit-lead.test.mjs
+++ b/tests/functions/submit-lead.test.mjs
@@ -145,3 +145,72 @@ test("returns 500 when every verifiable destination fails", async () => {
   const res = await post(completeLead());
   expect(res.statusCode).toBe(500);
 });
+
+test("mirrors complete leads to dotato when the webhook is configured — excluded from success", async () => {
+  vi.resetModules();
+  process.env.DOTATO_LEADS_WEBHOOK_URL =
+    "https://dotato.example/api/webhooks/hvg-leads/TESTTOKEN";
+  try {
+    const freshAxios = (await import("axios")).default;
+    freshAxios.post.mockReset();
+    freshAxios.post.mockImplementation((url) =>
+      url.includes("dotato.example")
+        ? Promise.reject(new Error("dotato down"))
+        : Promise.resolve({ data: { ok: true } })
+    );
+    const fresh = await import("../../netlify/functions/submit-lead.js");
+    const res = await fresh.handler(
+      { httpMethod: "POST", headers: {}, body: JSON.stringify(completeLead()) },
+      {}
+    );
+    // dotato down must never fail the seller
+    expect(res.statusCode).toBe(200);
+    const dotatoCalls = freshAxios.post.mock.calls.filter(([url]) =>
+      url.includes("dotato.example")
+    );
+    expect(dotatoCalls).toHaveLength(1);
+    const [, body] = dotatoCalls[0];
+    expect(body).toMatchObject({
+      stage: "complete",
+      name: "Test Seller",
+      consentTransactional: true,
+      consentMarketing: false,
+    });
+  } finally {
+    delete process.env.DOTATO_LEADS_WEBHOOK_URL;
+    vi.resetModules();
+  }
+});
+
+test("partial captures never reach dotato", async () => {
+  vi.resetModules();
+  process.env.DOTATO_LEADS_WEBHOOK_URL =
+    "https://dotato.example/api/webhooks/hvg-leads/TESTTOKEN";
+  try {
+    const freshAxios = (await import("axios")).default;
+    freshAxios.post.mockReset();
+    freshAxios.post.mockResolvedValue({ data: { ok: true } });
+    const fresh = await import("../../netlify/functions/submit-lead.js");
+    await fresh.handler(
+      {
+        httpMethod: "POST",
+        headers: {},
+        body: JSON.stringify({
+          stage: "partial",
+          submissionId: "11111111-2222-3333-4444-555555555555",
+          address: "123 Main St NW, Atlanta, GA",
+          fax: "",
+        }),
+      },
+      {}
+    );
+    const dotatoCalls = freshAxios.post.mock.calls.filter(([url]) =>
+      url.includes("dotato.example")
+    );
+    expect(dotatoCalls).toHaveLength(0);
+  } finally {
+    delete process.env.DOTATO_LEADS_WEBHOOK_URL;
+    vi.resetModules();
+  }
+});
+


### PR DESCRIPTION
HVG side of the lead handoff (dotato side: hasanihendrix1/dotato PR #174). submit-lead gains a fourth best-effort sink that POSTs complete submissions to dotato's token-in-path webhook. Env-gated by DOTATO_LEADS_WEBHOOK_URL (unset = dark, exactly as today); excluded from the seller-facing success decision; partials never sent; retries safe (dotato is idempotent on submissionId). 37/37 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)